### PR TITLE
Add simple Markdown editor with local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Markdown-Note-Editor-with-Local-Storage
+# Markdown Note Editor
+
+This is a simple browser-based Markdown note editor with the following features:
+
+- Live Markdown preview as you type.
+- Notes are saved automatically to your browser's local storage.
+- Each note stores a title and creation date for easy organization.
+- Manage multiple notes from the sidebar.
+- Export the current note as a `.md` or `.txt` file.
+
+Open `index.html` in your browser to start using the editor.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,114 @@
+(function() {
+    // Utility to generate unique IDs
+    function uid() {
+        return 'n-' + Date.now() + '-' + Math.floor(Math.random() * 1000);
+    }
+
+    // Markdown to HTML converter (very minimal)
+    function renderMarkdown(md) {
+        let html = md;
+        html = html.replace(/^### (.*$)/gim, '<h3>$1</h3>');
+        html = html.replace(/^## (.*$)/gim, '<h2>$1</h2>');
+        html = html.replace(/^# (.*$)/gim, '<h1>$1</h1>');
+        html = html.replace(/\*\*(.*?)\*\*/gim, '<strong>$1</strong>');
+        html = html.replace(/\*(.*?)\*/gim, '<em>$1</em>');
+        html = html.replace(/\n\n/g, '</p><p>');
+        html = html.replace(/\n/g, '<br>');
+        return '<p>' + html + '</p>';
+    }
+
+    const listEl = document.getElementById('list');
+    const titleEl = document.getElementById('title');
+    const dateEl = document.getElementById('date');
+    const markdownEl = document.getElementById('markdown');
+    const previewEl = document.getElementById('preview');
+
+    let notes = [];
+    let currentId = null;
+
+    function loadNotes() {
+        const saved = localStorage.getItem('notes');
+        if (saved) {
+            notes = JSON.parse(saved);
+        }
+    }
+
+    function saveNotes() {
+        localStorage.setItem('notes', JSON.stringify(notes));
+    }
+
+    function refreshList() {
+        listEl.innerHTML = '';
+        notes.forEach(n => {
+            const li = document.createElement('li');
+            li.textContent = n.title || 'Untitled';
+            li.dataset.id = n.id;
+            if (n.id === currentId) li.classList.add('active');
+            li.onclick = () => selectNote(n.id);
+            listEl.appendChild(li);
+        });
+    }
+
+    function selectNote(id) {
+        const note = notes.find(n => n.id === id);
+        if (!note) return;
+        currentId = id;
+        titleEl.value = note.title;
+        markdownEl.value = note.body;
+        dateEl.textContent = 'Created: ' + new Date(note.date).toLocaleString();
+        updatePreview();
+        refreshList();
+    }
+
+    function newNote() {
+        const note = {
+            id: uid(),
+            title: '',
+            body: '',
+            date: Date.now()
+        };
+        notes.unshift(note);
+        saveNotes();
+        refreshList();
+        selectNote(note.id);
+    }
+
+    function updateCurrent() {
+        const note = notes.find(n => n.id === currentId);
+        if (!note) return;
+        note.title = titleEl.value;
+        note.body = markdownEl.value;
+        saveNotes();
+        refreshList();
+        updatePreview();
+    }
+
+    function updatePreview() {
+        previewEl.innerHTML = renderMarkdown(markdownEl.value);
+    }
+
+    document.getElementById('new-note').addEventListener('click', newNote);
+    titleEl.addEventListener('input', updateCurrent);
+    markdownEl.addEventListener('input', updateCurrent);
+
+    document.getElementById('export-md').addEventListener('click', () => exportNote('md'));
+    document.getElementById('export-txt').addEventListener('click', () => exportNote('txt'));
+
+    function exportNote(ext) {
+        const note = notes.find(n => n.id === currentId);
+        if (!note) return;
+        const blob = new Blob([note.body], { type: 'text/plain;charset=utf-8' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = (note.title || 'note') + '.' + ext;
+        a.click();
+        URL.revokeObjectURL(a.href);
+    }
+
+    // Initialization
+    loadNotes();
+    if (notes.length) {
+        selectNote(notes[0].id);
+    }
+    refreshList();
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Markdown Note Editor</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="container">
+        <aside id="notes-list">
+            <h2>Notes</h2>
+            <button id="new-note">New Note</button>
+            <ul id="list"></ul>
+        </aside>
+        <main id="editor">
+            <input id="title" type="text" placeholder="Note Title">
+            <div id="date"></div>
+            <div id="panes">
+                <textarea id="markdown" placeholder="Write your note in Markdown..."></textarea>
+                <div id="preview"></div>
+            </div>
+            <button id="export-md">Export as .md</button>
+            <button id="export-txt">Export as .txt</button>
+        </main>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,79 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    height: 100vh;
+}
+
+#container {
+    display: flex;
+    flex: 1;
+}
+
+#notes-list {
+    width: 200px;
+    background: #f2f2f2;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+#notes-list ul {
+    list-style: none;
+    padding: 0;
+}
+
+#notes-list li {
+    padding: 5px;
+    cursor: pointer;
+}
+
+#notes-list li.active {
+    background: #ddd;
+}
+
+#editor {
+    flex: 1;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+}
+
+#title {
+    font-size: 1.2em;
+    padding: 5px;
+    margin-bottom: 5px;
+}
+
+#date {
+    font-size: 0.8em;
+    color: #666;
+    margin-bottom: 5px;
+}
+
+#panes {
+    display: flex;
+    flex: 1;
+    gap: 10px;
+}
+
+#markdown, #preview {
+    width: 50%;
+    height: 100%;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+#markdown {
+    font-family: monospace;
+    resize: none;
+}
+
+#preview {
+    border-left: 1px solid #ccc;
+    overflow-y: auto;
+}
+
+button {
+    margin-top: 5px;
+}


### PR DESCRIPTION
## Summary
- create a basic browser Markdown note editor
- add styles for editor layout and note list
- implement JS logic for saving notes to local storage, live preview and exporting
- document usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e3c19c6d083328ecaf477d3a92e1b